### PR TITLE
fix race read while running proxy

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -51,10 +51,11 @@ func (w *chanWriter) Write(data []byte) (int, error) {
 	// so we can directly read the buffer in another goroutine while still being used in exec.Command goroutine
 
 	// copy to be written buffer and pass it into channel
-	bufferToWrite := append([]byte{}, data...)
+	bufferToWrite := make([]byte, len(data))
+	written := copy(bufferToWrite, data)
 	w.out <- bufferToWrite
 
-	return len(bufferToWrite), nil
+	return written, nil
 }
 
 // Proxy runs inkspace instance in background and

--- a/proxy.go
+++ b/proxy.go
@@ -46,6 +46,11 @@ type chanWriter struct {
 }
 
 func (w *chanWriter) Write(data []byte) (int, error) {
+
+	// look like the buffer being reused internally by the exec.Command
+	// so we can directly read the buffer in another goroutine while still being used in exec.Command goroutine
+
+	// copy to be written buffer and pass it into channel
 	bufferToWrite := append([]byte{}, data...)
 	w.out <- bufferToWrite
 

--- a/proxy.go
+++ b/proxy.go
@@ -46,9 +46,10 @@ type chanWriter struct {
 }
 
 func (w *chanWriter) Write(data []byte) (int, error) {
-	w.out <- data
+	bufferToWrite := append([]byte{}, data...)
+	w.out <- bufferToWrite
 
-	return len(data), nil
+	return len(bufferToWrite), nil
 }
 
 // Proxy runs inkspace instance in background and


### PR DESCRIPTION
Look like the #1 are caused by we are read the same buffer with the exec.Cmd are internally using to write the buffer,
In order to avoid race this PR just copy the buffer before pass it into chan for reading.